### PR TITLE
fix NetCDF build error and move to Julia 1.1

### DIFF
--- a/esdl-singleuser-julia-nb/Dockerfile
+++ b/esdl-singleuser-julia-nb/Dockerfile
@@ -12,7 +12,7 @@ RUN wget https://julialang-s3.julialang.org/bin/linux/x64/0.6/julia-0.6.2-linux-
 RUN mkdir julia && tar xzf julia-0.6.2-linux-x86_64.tar.gz -C julia --strip-components 1
 RUN PATH="/srv/jupyterhub/julia/bin:$PATH"
 WORKDIR /srv/jupyterhub/julia
-RUN echo 'Pkg.resolve();Pkg.add("IJulia")' > IJulia.jl
+RUN echo 'Pkg.resolve();Pkg.build("ESDL");Pkg.add("IJulia")' > IJulia.jl
 RUN echo 'Pkg.add("ECharts");Pkg.add("PyPlot");Pkg.add("PlotlyJS");Pkg.add("GR");Pkg.add("ProgressMeter");Pkg.clone("https://github.com/slundberg/PmapProgressMeter.jl")' > plotpackages.jl
 RUN echo 'using Compose, ESDL, GR, ESDLPlots, ProgressMeter, PmapProgressMeter, ECharts, PyPlot' > precomp.jl
 
@@ -40,15 +40,18 @@ USER root
 
 WORKDIR /srv/jupyterhub
 
-RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.2-linux-x86_64.tar.gz
-RUN mkdir julia-1.0 && tar xzf julia-1.0.2-linux-x86_64.tar.gz -C julia-1.0 --strip-components 1
-WORKDIR /srv/jupyterhub/julia-1.0
-RUN echo 'using Pkg\n pkg"add StatsBase#master IJulia ProgressMeter GR ECharts PyPlot WeightedOnlineStats https://github.com/meggart/SentinelMissings.jl https://github.com/esa-esdl/ESDL.jl https://github.com/esa-esdl/ESDLPlots.jl"\n pkg"precompile"' > packages.jl
-RUN /srv/jupyterhub/julia-1.0/bin/julia -e "println(DEPOT_PATH)"
-WORKDIR /srv/jupyterhub/julia-1.0
+RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz
+RUN mkdir julia-1.1 && tar xzf julia-1.1.0-linux-x86_64.tar.gz -C julia-1.1 --strip-components 1
+WORKDIR /srv/jupyterhub/julia-1.1
+RUN echo 'using Pkg\n pkg"add https://github.com/meggart/NetCDF.jl#noconda"\n\n pkg"build NetCDF"\n using NetCDF' > netcdf.jl
+RUN echo 'using Pkg\n pkg"add StatsBase IJulia ProgressMeter GR ECharts PyPlot WeightedOnlineStats https://github.com/meggart/SentinelMissings.jl https://github.com/esa-esdl/ESDL.jl https://github.com/esa-esdl/ESDLPlots.jl"\n pkg"precompile"' > packages.jl
+RUN /srv/jupyterhub/julia-1.1/bin/julia -e "println(DEPOT_PATH)"
+WORKDIR /srv/jupyterhub/julia-1.1
 USER $NB_USER
-WORKDIR /srv/jupyterhub/julia-1.0
+WORKDIR /srv/jupyterhub/julia-1.1
 ENV ESDL_WORKDIR /home/jovyan/tmp
-RUN /srv/jupyterhub/julia-1.0/bin/julia packages.jl
+RUN /srv/jupyterhub/julia-1.1/bin/julia netcdf.jl
+
+RUN /srv/jupyterhub/julia-1.1/bin/julia packages.jl
 
 WORKDIR /home/jovyan/work


### PR DESCRIPTION
This should fix the julia NetCDF build error. I did not find the reason for the error, however, as a quick fix I removed the Conda dependency from the NetCDF package in my fork https://github.com/meggart/NetCDF.jl/tree/noconda, since we install libnetcdf through apt-get anyway. 

However, I should find out why the normal build does not work...