### PR TITLE
update Julia installation instructions

### DIFF
--- a/esdl-singleuser-julia-nb/Dockerfile
+++ b/esdl-singleuser-julia-nb/Dockerfile
@@ -42,15 +42,20 @@ USER root
 
 WORKDIR /srv/jupyterhub
 
-RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.0/julia-1.0.2-linux-x86_64.tar.gz
-RUN mkdir julia-1.0 && tar xzf julia-1.0.2-linux-x86_64.tar.gz -C julia-1.0 --strip-components 1
-WORKDIR /srv/jupyterhub/julia-1.0
-RUN echo 'using Pkg\n pkg"add StatsBase#master IJulia ProgressMeter GR ECharts PyPlot WeightedOnlineStats https://github.com/meggart/SentinelMissings.jl https://github.com/esa-esdl/ESDL.jl https://github.com/esa-esdl/ESDLPlots.jl"\n pkg"precompile"' > packages.jl
-RUN /srv/jupyterhub/julia-1.0/bin/julia -e "println(DEPOT_PATH)"
-WORKDIR /srv/jupyterhub/julia-1.0
+RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.1/julia-1.1.0-linux-x86_64.tar.gz
+RUN mkdir julia-1.1 && tar xzf julia-1.1.0-linux-x86_64.tar.gz -C julia-1.1 --strip-components 1
 USER $NB_USER
-WORKDIR /srv/jupyterhub/julia-1.0
 ENV ESDL_WORKDIR /home/jovyan/tmp
-RUN /srv/jupyterhub/julia-1.0/bin/julia packages.jl
-
+ENV JULIA_DEPOT_PATH /home/jovyan/julia_depots
+WORKDIR /srv/jupyterhub/julia-1.1
+RUN /srv/jupyterhub/julia-1.1/bin/julia -e 'using Pkg;pkg"add WebIO@0.6 ColorTypes MultivariateStats IJulia PackageCompiler ProgressMeter GR ECharts PyPlot https://github.com/gdkrmr/WeightedOnlineStats.jl"'
+WORKDIR /home/jovyan/julia_depots/registries/
+RUN git clone https://git.bgc-jena.mpg.de/fgans/BGIRegistries
+WORKDIR /srv/jupyterhub/julia-1.1
+RUN /srv/jupyterhub/julia-1.1/bin/julia -e 'using Pkg; pkg"add ESDL"'
+RUN /srv/jupyterhub/julia-1.1/bin/julia -e 'using Pkg;pkg"add SentinelMissings ZarrNative ESDLPlots"'
+RUN /srv/jupyterhub/julia-1.1/bin/julia -e 'using Pkg;pkg"precompile"'
+RUN /srv/jupyterhub/julia-1.1/bin/julia -e 'using Pkg;pkg"add MultivariateAnomalies#master";pkg"precompile"'
+#The following could work when we have the cube in object store, so that unit tests can generate snoop file
+#RUN /srv/jupyterhub/julia-1.1/bin/julia -e 'using PackageCompiler;compile_package("ESDL", "ImageMagick","ESDLPlots", force = true)'
 WORKDIR /home/jovyan/work


### PR DESCRIPTION
This updates the Julia container to use Julia 1.1 and install a more recent version of ESDL.jl so that it can process the new zarr datacube in ESDCv2.0.0. 

It would be nice if you could merge and rebuild the container soon.